### PR TITLE
Fix compile in C99 mode

### DIFF
--- a/simul.c
+++ b/simul.c
@@ -86,7 +86,7 @@ char *timestamp() {
     return datestring;
 }
 
-inline void begin(char *str) {
+static inline void begin(char *str) {
     if (verbose > 0 && rank == 0) {
         gettimeofday(&t1, NULL);
         fprintf(stdout, "%s:\tBeginning %s\n", timestamp(), str);
@@ -94,7 +94,7 @@ inline void begin(char *str) {
     }
 }
 
-inline void end(char *str) {
+static inline void end(char *str) {
     double elapsed;
 
     MPI_Barrier(MPI_COMM_WORLD);


### PR DESCRIPTION
From http://clang.llvm.org/compatibility.html#inline :
> By default, Clang builds C code in GNU C17 mode, so it uses standard C99 semantics for the inline keyword. These semantics are different from those in GNU C89 mode, which is the default mode in versions of GCC prior to 5.0.

> In C99, inline means that a function's definition is provided only for inlining, and that there is another definition (without inline) somewhere else in the program. That means that this program is incomplete, because if add isn't inlined (for example, when compiling without optimization), then main will have an unresolved reference to that other definition. 